### PR TITLE
Fixed copy and paste bug where wrong escape chars for arguments were being retrieved

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/cli/shell/Shell.java
+++ b/src/main/java/org/codehaus/plexus/util/cli/shell/Shell.java
@@ -160,7 +160,7 @@ public class Shell
 
             if ( isQuotedArgumentsEnabled() )
             {
-                char[] escapeChars = getEscapeChars( isSingleQuotedExecutableEscaped(), isDoubleQuotedExecutableEscaped() );
+                char[] escapeChars = getEscapeChars( isSingleQuotedArgumentEscaped(), isDoubleQuotedArgumentEscaped() );
 
                 sb.append( StringUtils.quoteAndEscape( arguments[i], getArgumentQuoteDelimiter(), escapeChars, getQuotingTriggerChars(), '\\', false ) );
             }

--- a/src/test/java/org/codehaus/plexus/util/cli/shell/BourneShellTest.java
+++ b/src/test/java/org/codehaus/plexus/util/cli/shell/BourneShellTest.java
@@ -101,6 +101,17 @@ public class BourneShellTest
         assertTrue( cli.endsWith( "\'" + args[0] + "\'" ) );
     }
 
+    public void testAddSingleQuotesAndEscapeSingleQuotesOnArgumentWithSpaces()
+    {
+        Shell sh = newShell();
+
+        String[] args = { "some 'arg' with spaces and quotes" };
+
+        List shellCommandLine = sh.getCommandLine("chmod",  args );
+
+        assertEquals("null \'some \\'arg\\' with spaces and quotes\'", shellCommandLine.get(shellCommandLine.size() - 1));
+    }
+
     public void testArgumentsWithsemicolon()
     {
 


### PR DESCRIPTION
Shell has a bug where it uses the _executable_ isSingleQuotedExecutableEscaped() and isDoubleQuotedExecutableEscaped() flags to build the escapeChars for _arguments_.  This has the result that no quotes in arguments are escaped in the BourneShell, resulting in a broken command line.

This is preventing me using the Maven release plugin as I need to pass a gpg passphrase containing single quotes.
