### PR TITLE
Allowed Shell to take an escape pattern (in Java MessageFormat) to allow correct escaping of quotes in arguments

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/StringUtils.java
+++ b/src/main/java/org/codehaus/plexus/util/StringUtils.java
@@ -2288,18 +2288,37 @@ public class StringUtils
                                 char escapeChar,
                                 boolean force )
     {
+        return quoteAndEscape(source, quoteChar, escapedChars, quotingTriggers, escapeChar + "%s", force);
+    }
+
+    /**
+     * @param source
+     * @param quoteChar
+     * @param escapedChars
+     * @param quotingTriggers
+     * @param escapePattern
+     * @param force
+     * @return the String quoted and escaped
+     * @since 3.0.4
+     */
+    public static String quoteAndEscape(String source,
+                                        char quoteChar,
+                                        final char[] escapedChars,
+                                        final char[] quotingTriggers,
+                                        String escapePattern,
+                                        boolean force) {
         if ( source == null )
         {
             return null;
         }
 
         if ( !force && source.startsWith( Character.toString( quoteChar ) )
-             && source.endsWith( Character.toString( quoteChar ) ) )
+                && source.endsWith( Character.toString( quoteChar ) ) )
         {
             return source;
         }
 
-        String escaped = escape( source, escapedChars, escapeChar );
+        String escaped = escape( source, escapedChars, escapePattern );
 
         boolean quote = false;
         if ( force )
@@ -2339,6 +2358,18 @@ public class StringUtils
      */
     public static String escape( String source, final char[] escapedChars, char escapeChar )
     {
+        return escape(source, escapedChars, escapeChar + "%s");
+    }
+
+    /**
+     * @param source
+     * @param escapedChars
+     * @param escapePattern
+     * @return the String escaped
+     * @since 3.0.4
+     */
+    public static String escape( String source, final char[] escapedChars, String escapePattern )
+    {
         if ( source == null )
         {
             return null;
@@ -2357,10 +2388,12 @@ public class StringUtils
 
             if ( result > -1 )
             {
-                buffer.append( escapeChar );
+                buffer.append( String.format(escapePattern, c) );
             }
-
-            buffer.append( c );
+            else
+            {
+                buffer.append( c );
+            }
         }
 
         return buffer.toString();

--- a/src/main/java/org/codehaus/plexus/util/cli/shell/BourneShell.java
+++ b/src/main/java/org/codehaus/plexus/util/cli/shell/BourneShell.java
@@ -60,6 +60,7 @@ public class BourneShell
         setSingleQuotedArgumentEscaped( true );
         setSingleQuotedExecutableEscaped( false );
         setQuotedExecutableEnabled( true );
+        setArgumentEscapePattern("'\\%s'");
 
         if ( isLoginShell )
         {

--- a/src/main/java/org/codehaus/plexus/util/cli/shell/Shell.java
+++ b/src/main/java/org/codehaus/plexus/util/cli/shell/Shell.java
@@ -66,6 +66,8 @@ public class Shell
 
     private char exeQuoteDelimiter = '\"';
 
+    private String argumentEscapePattern = "\\%s";
+
     /**
      * Set the command to execute the shell (eg. COMMAND.COM, /bin/bash,...)
      *
@@ -162,7 +164,7 @@ public class Shell
             {
                 char[] escapeChars = getEscapeChars( isSingleQuotedArgumentEscaped(), isDoubleQuotedArgumentEscaped() );
 
-                sb.append( StringUtils.quoteAndEscape( arguments[i], getArgumentQuoteDelimiter(), escapeChars, getQuotingTriggerChars(), '\\', false ) );
+                sb.append( StringUtils.quoteAndEscape( arguments[i], getArgumentQuoteDelimiter(), escapeChars, getQuotingTriggerChars(), getArgumentEscapePattern(), false ) );
             }
             else
             {
@@ -242,6 +244,15 @@ public class Shell
     protected char getExecutableQuoteDelimiter()
     {
         return exeQuoteDelimiter;
+    }
+
+    protected void setArgumentEscapePattern(String argumentEscapePattern)
+    {
+        this.argumentEscapePattern = argumentEscapePattern;
+    }
+
+    protected String getArgumentEscapePattern() {
+        return argumentEscapePattern;
     }
 
     /**
@@ -395,5 +406,4 @@ public class Shell
     {
         this.singleQuotedExecutableEscaped = singleQuotedExecutableEscaped;
     }
-
 }

--- a/src/test/java/org/codehaus/plexus/util/StringUtilsTest.java
+++ b/src/test/java/org/codehaus/plexus/util/StringUtilsTest.java
@@ -123,6 +123,17 @@ public class StringUtilsTest
         assertEquals( check, result );
     }
 
+    public void testQuote_EscapeEmbeddedSingleQuotesWithPattern()
+    {
+        String src = "This \'is a\' test";
+        String check = "\'This pre'postis apre'post test\'";
+
+        char[] escaped = { '\'', '\"' };
+        String result = StringUtils.quoteAndEscape( src, '\'', escaped, new char[]{ ' ' }, "pre%spost", false );
+
+        assertEquals( check, result );
+    }
+
     public void testQuote_EscapeEmbeddedDoubleQuotesAndSpaces()
     {
         String src = "This \"is a\" test";

--- a/src/test/java/org/codehaus/plexus/util/cli/shell/BourneShellTest.java
+++ b/src/test/java/org/codehaus/plexus/util/cli/shell/BourneShellTest.java
@@ -101,15 +101,20 @@ public class BourneShellTest
         assertTrue( cli.endsWith( "\'" + args[0] + "\'" ) );
     }
 
-    public void testAddSingleQuotesAndEscapeSingleQuotesOnArgumentWithSpaces()
+    public void testEscapeSingleQuotesOnArgument()
     {
         Shell sh = newShell();
 
-        String[] args = { "some 'arg' with spaces and quotes" };
+        sh.setWorkingDirectory( "/usr/bin" );
+        sh.setExecutable( "chmod" );
 
-        List shellCommandLine = sh.getCommandLine("chmod",  args );
+        String[] args = { "arg'withquote" };
 
-        assertEquals("null \'some \\'arg\\' with spaces and quotes\'", shellCommandLine.get(shellCommandLine.size() - 1));
+        List shellCommandLine = sh.getShellCommandLine( args );
+
+        String cli = StringUtils.join( shellCommandLine.iterator(), " " );
+        System.out.println( cli );
+        assertEquals("cd /usr/bin && chmod 'arg'\\''withquote'", shellCommandLine.get(shellCommandLine.size() - 1));
     }
 
     public void testArgumentsWithsemicolon()


### PR DESCRIPTION
Bourne shell requires a ' in an argument to be escaped as '\'' (see http://wiki.bash-hackers.org/syntax/quoting#strong_quoting).  This patch enhances Shell & StringUtils to allow specifying a pattern to use to escape a character rather than simply a single character to precede the character that needs to be escaped.
