### PR TITLE
BourneShell.getExecutionPreamble does not escape the dollar sign in a directory name

### DIFF
--- a/src/test/java/org/codehaus/plexus/util/cli/shell/BourneShellTest.java
+++ b/src/test/java/org/codehaus/plexus/util/cli/shell/BourneShellTest.java
@@ -69,6 +69,18 @@ public class BourneShellTest
         assertEquals( "/bin/sh -c cd \"\\usr\\local\\\'something else\'\" && chmod", executable );
     }
 
+    public void testQuoteWorkingDirectoryAndExecutable_WDPathWithDollarSign()
+    {
+        Shell sh = newShell();
+
+        sh.setWorkingDirectory( "/tmp/abc$xyz" );
+        sh.setExecutable( "chmod" );
+
+        String commandLine = sh.getCommandLine( "", new String[]{} ).get(0);
+
+        assertEquals( "cd \"/tmp/abc\\$xyz\" && chmod", commandLine );
+    }
+
     public void testPreserveSingleQuotesOnArgument()
     {
         Shell sh = newShell();


### PR DESCRIPTION
`BourneShell.getExecutionPreamble` calls `unifyQuotes( dir )`, which calls `StringUtils.quoteAndEscape( path, '\"', BASH_QUOTING_TRIGGER_CHARS );`, which calls six-arg `.quoteAndEscape` in such a way that, for example, `abc$xyz` becomes `"abc$xyz"` and `.getExecutionPreamble` produces `cd "abc$xyz" && ...` which does not work because of shell interpolation of `$xyz` inside double quotes.
