### PR TITLE
DirectoryWalker: sort traversed files to have consistent walking order

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/DirectoryWalker.java
+++ b/src/main/java/org/codehaus/plexus/util/DirectoryWalker.java
@@ -18,6 +18,7 @@ package org.codehaus.plexus.util;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
@@ -128,6 +129,8 @@ public class DirectoryWalker
     private List<DirectoryWalkListener> listeners;
 
     private boolean debugEnabled = false;
+
+    private boolean sorted = false;
 
     public DirectoryWalker()
     {
@@ -267,6 +270,11 @@ public class DirectoryWalker
         return false;
     }
 
+    public boolean isSorted()
+    {
+        return sorted;
+    }
+
     private String relativeToBaseDir( File file )
     {
         return file.getAbsolutePath().substring( baseDirOffset + 1 );
@@ -345,6 +353,8 @@ public class DirectoryWalker
         {
             return;
         }
+
+        Arrays.sort(files);
 
         DirectoryWalker.DirStackEntry curStackEntry = new DirectoryWalker.DirStackEntry( dir, files.length );
         if ( dirStack.isEmpty() )
@@ -427,4 +437,11 @@ public class DirectoryWalker
         }
     }
 
+    /**
+     * @param sorted If true, files are walked in alphabetical order according to {@link File#compareTo(java.io.File)}. Default is false.
+     */
+    public void setSorted(boolean sorted)
+    {
+        this.sorted = sorted;
+    }
 }

--- a/src/main/java/org/codehaus/plexus/util/DirectoryWalker.java
+++ b/src/main/java/org/codehaus/plexus/util/DirectoryWalker.java
@@ -354,7 +354,9 @@ public class DirectoryWalker
             return;
         }
 
-        Arrays.sort(files);
+        if ( sorted ) {
+            Arrays.sort(files);
+        }
 
         DirectoryWalker.DirStackEntry curStackEntry = new DirectoryWalker.DirStackEntry( dir, files.length );
         if ( dirStack.isEmpty() )

--- a/src/test/java/org/codehaus/plexus/util/DirectoryWalkerTest.java
+++ b/src/test/java/org/codehaus/plexus/util/DirectoryWalkerTest.java
@@ -31,6 +31,7 @@ public class DirectoryWalkerTest extends TestCase {
 
         WalkCollector collector = new WalkCollector();
         walker.addDirectoryWalkListener( collector );
+        walker.setSorted(true);
 
         walker.scan();
 


### PR DESCRIPTION
Enhances DirectoryWalker with an option to sort the files during the walk.
By default, this option is turned off - solely to avoid performance regression.

usage:

```
...
walker.setSorted(true);
...
```
