### PR TITLE
/bin/sh may not be the BourneShell.

### DIFF
--- a/src/main/java/org/codehaus/plexus/util/cli/shell/BourneShell.java
+++ b/src/main/java/org/codehaus/plexus/util/cli/shell/BourneShell.java
@@ -37,7 +37,7 @@ public class BourneShell
     public BourneShell( boolean isLoginShell )
     {
         setUnconditionalQuoting( true );
-        setShellCommand( "/bin/sh" );
+        setShellCommand( "/bin/bash" );
         setArgumentQuoteDelimiter( '\'' );
         setExecutableQuoteDelimiter( '\'' );
         setSingleQuotedArgumentEscaped( true );

--- a/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
+++ b/src/test/java/org/codehaus/plexus/util/cli/CommandlineTest.java
@@ -243,7 +243,7 @@ public class CommandlineTest
 
         assertEquals( "Command line size", 3, shellCommandline.length );
 
-        assertEquals( "/bin/sh", shellCommandline[0] );
+        assertEquals( "/bin/bash", shellCommandline[0] );
         assertEquals( "-c", shellCommandline[1] );
         String expectedShellCmd = "'/bin/echo' 'hello world'";
         if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
@@ -273,7 +273,7 @@ public class CommandlineTest
 
         assertEquals( "Command line size", 3, shellCommandline.length );
 
-        assertEquals( "/bin/sh", shellCommandline[0] );
+        assertEquals( "/bin/bash", shellCommandline[0] );
         assertEquals( "-c", shellCommandline[1] );
         String expectedShellCmd = "cd '" + root.getAbsolutePath()
                                   + "path with spaces' && '/bin/echo' 'hello world'";
@@ -302,7 +302,7 @@ public class CommandlineTest
 
         assertEquals( "Command line size", 3, shellCommandline.length );
 
-        assertEquals( "/bin/sh", shellCommandline[0] );
+        assertEquals( "/bin/bash", shellCommandline[0] );
         assertEquals( "-c", shellCommandline[1] );
         String expectedShellCmd = "'/bin/echo' ''\"'\"'hello world'\"'\"''";
         if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
@@ -325,7 +325,7 @@ public class CommandlineTest
 
         assertEquals( "Command line size", 3, shellCommandline.length );
 
-        assertEquals( "/bin/sh", shellCommandline[0] );
+        assertEquals( "/bin/bash", shellCommandline[0] );
         assertEquals( "-c", shellCommandline[1] );
 
         if ( Os.isFamily( Os.FAMILY_WINDOWS ) )
@@ -485,7 +485,7 @@ public class CommandlineTest
         }
 
         Commandline cmd = new Commandline();
-        //cmd.getShell().setShellCommand( "/bin/sh" );
+        //cmd.getShell().setShellCommand( "/bin/bash" );
         cmd.getShell().setQuotedArgumentsEnabled( true );
         cmd.setExecutable( "cat" );
         if ( Os.isFamily( Os.FAMILY_WINDOWS ) )

--- a/src/test/java/org/codehaus/plexus/util/cli/shell/BourneShellTest.java
+++ b/src/test/java/org/codehaus/plexus/util/cli/shell/BourneShellTest.java
@@ -41,7 +41,7 @@ public class BourneShellTest
 
         String executable = StringUtils.join( sh.getShellCommandLine( new String[]{} ).iterator(), " " );
 
-        assertEquals( "/bin/sh -c cd '/usr/local/bin' && 'chmod'", executable );
+        assertEquals( "/bin/bash -c cd '/usr/local/bin' && 'chmod'", executable );
     }
 
     public void testQuoteWorkingDirectoryAndExecutable_WDPathWithSingleQuotes()
@@ -53,7 +53,7 @@ public class BourneShellTest
 
         String executable = StringUtils.join( sh.getShellCommandLine( new String[]{} ).iterator(), " " );
 
-        assertEquals( "/bin/sh -c cd '/usr/local/'\"'\"'something else'\"'\"'' && 'chmod'", executable );
+        assertEquals( "/bin/bash -c cd '/usr/local/'\"'\"'something else'\"'\"'' && 'chmod'", executable );
     }
 
     public void testQuoteWorkingDirectoryAndExecutable_WDPathWithSingleQuotes_BackslashFileSep()
@@ -65,7 +65,7 @@ public class BourneShellTest
 
         String executable = StringUtils.join( sh.getShellCommandLine( new String[]{} ).iterator(), " " );
 
-        assertEquals( "/bin/sh -c cd '\\usr\\local\\\'\"'\"'something else'\"'\"'' && 'chmod'", executable );
+        assertEquals( "/bin/bash -c cd '\\usr\\local\\\'\"'\"'something else'\"'\"'' && 'chmod'", executable );
     }
 
     public void testPreserveSingleQuotesOnArgument()
@@ -143,7 +143,7 @@ public class BourneShellTest
         String[] lines = commandline.getShellCommandline();
         System.out.println( Arrays.asList( lines ) );
 
-        assertEquals( "/bin/sh", lines[0] );
+        assertEquals( "/bin/bash", lines[0] );
         assertEquals( "-c", lines[1] );
         assertEquals( "'chmod' '--password' ';password'", lines[2] );
 
@@ -155,7 +155,7 @@ public class BourneShellTest
         lines = commandline.getShellCommandline();
         System.out.println( Arrays.asList( lines ) );
 
-        assertEquals( "/bin/sh", lines[0] );
+        assertEquals( "/bin/bash", lines[0] );
         assertEquals( "-c", lines[1] );
         assertEquals( "'chmod' '--password' ';password'", lines[2] );
 
@@ -203,7 +203,7 @@ public class BourneShellTest
         String[] lines = commandline.getShellCommandline();
         System.out.println( Arrays.asList( lines ) );
 
-        assertEquals( "/bin/sh", lines[0] );
+        assertEquals( "/bin/bash", lines[0] );
         assertEquals( "-c", lines[1] );
         assertEquals( "'chmod' ' ' '|' '&&' '||' ';' ';;' '&' '()' '<' '<<' '>' '>>' '*' '?' '[' ']' '{' '}' '`'",
                       lines[2] );


### PR DESCRIPTION
In Debian, default shell (`/bin/sh`) is Dash instead of Bash, what may fail with Bash scripts.

Taken from https://wiki.debian.org/Shell :

> Up to DebianLenny, the default /bin/sh shell was bash. Starting with DebianSqueeze, the default shell will be dash (see DashAsBinSh).

So, it is incorrect to assume that `/bin/sh` is the BourneShell.
